### PR TITLE
Check for duplicate files

### DIFF
--- a/CryptoJS/core.js
+++ b/CryptoJS/core.js
@@ -1,0 +1,740 @@
+/**
+ * CryptoJS core components.
+ */
+var CryptoJS = CryptoJS || (function (Math, undefined) {
+    /*
+     * Local polyfil of Object.create
+     */
+    var create = Object.create || (function () {
+        function F() {};
+
+        return function (obj) {
+            var subtype;
+
+            F.prototype = obj;
+
+            subtype = new F();
+
+            F.prototype = null;
+
+            return subtype;
+        };
+    }())
+
+    /**
+     * CryptoJS namespace.
+     */
+    var C = {};
+
+    /**
+     * Library namespace.
+     */
+    var C_lib = C.lib = {};
+
+    /**
+     * Base object for prototypal inheritance.
+     */
+    var Base = C_lib.Base = (function () {
+
+
+        return {
+            /**
+             * Creates a new object that inherits from this object.
+             *
+             * @param {Object} overrides Properties to copy into the new object.
+             *
+             * @return {Object} The new object.
+             *
+             * @static
+             *
+             * @example
+             *
+             *     var MyType = CryptoJS.lib.Base.extend({
+             *         field: 'value',
+             *
+             *         method: function () {
+             *         }
+             *     });
+             */
+            extend: function (overrides) {
+                // Spawn
+                var subtype = create(this);
+
+                // Augment
+                if (overrides) {
+                    subtype.mixIn(overrides);
+                }
+
+                // Create default initializer
+                if (!subtype.hasOwnProperty('init') || this.init === subtype.init) {
+                    subtype.init = function () {
+                        subtype.$super.init.apply(this, arguments);
+                    };
+                }
+
+                // Initializer's prototype is the subtype object
+                subtype.init.prototype = subtype;
+
+                // Reference supertype
+                subtype.$super = this;
+
+                return subtype;
+            },
+
+            /**
+             * Extends this object and runs the init method.
+             * Arguments to create() will be passed to init().
+             *
+             * @return {Object} The new object.
+             *
+             * @static
+             *
+             * @example
+             *
+             *     var instance = MyType.create();
+             */
+            create: function () {
+                var instance = this.extend();
+                instance.init.apply(instance, arguments);
+
+                return instance;
+            },
+
+            /**
+             * Initializes a newly created object.
+             * Override this method to add some logic when your objects are created.
+             *
+             * @example
+             *
+             *     var MyType = CryptoJS.lib.Base.extend({
+             *         init: function () {
+             *             // ...
+             *         }
+             *     });
+             */
+            init: function () {
+            },
+
+            /**
+             * Copies properties into this object.
+             *
+             * @param {Object} properties The properties to mix in.
+             *
+             * @example
+             *
+             *     MyType.mixIn({
+             *         field: 'value'
+             *     });
+             */
+            mixIn: function (properties) {
+                for (var propertyName in properties) {
+                    if (properties.hasOwnProperty(propertyName)) {
+                        this[propertyName] = properties[propertyName];
+                    }
+                }
+
+                // IE won't copy toString using the loop above
+                if (properties.hasOwnProperty('toString')) {
+                    this.toString = properties.toString;
+                }
+            },
+
+            /**
+             * Creates a copy of this object.
+             *
+             * @return {Object} The clone.
+             *
+             * @example
+             *
+             *     var clone = instance.clone();
+             */
+            clone: function () {
+                return this.init.prototype.extend(this);
+            }
+        };
+    }());
+
+    /**
+     * An array of 32-bit words.
+     *
+     * @property {Array} words The array of 32-bit words.
+     * @property {number} sigBytes The number of significant bytes in this word array.
+     */
+    var WordArray = C_lib.WordArray = Base.extend({
+        /**
+         * Initializes a newly created word array.
+         *
+         * @param {Array} words (Optional) An array of 32-bit words.
+         * @param {number} sigBytes (Optional) The number of significant bytes in the words.
+         *
+         * @example
+         *
+         *     var wordArray = CryptoJS.lib.WordArray.create();
+         *     var wordArray = CryptoJS.lib.WordArray.create([0x00010203, 0x04050607]);
+         *     var wordArray = CryptoJS.lib.WordArray.create([0x00010203, 0x04050607], 6);
+         */
+        init: function (words, sigBytes) {
+            words = this.words = words || [];
+
+            if (sigBytes != undefined) {
+                this.sigBytes = sigBytes;
+            } else {
+                this.sigBytes = words.length * 4;
+            }
+        },
+
+        /**
+         * Converts this word array to a string.
+         *
+         * @param {Encoder} encoder (Optional) The encoding strategy to use. Default: CryptoJS.enc.Hex
+         *
+         * @return {string} The stringified word array.
+         *
+         * @example
+         *
+         *     var string = wordArray + '';
+         *     var string = wordArray.toString();
+         *     var string = wordArray.toString(CryptoJS.enc.Utf8);
+         */
+        toString: function (encoder) {
+            return (encoder || Hex).stringify(this);
+        },
+
+        /**
+         * Concatenates a word array to this word array.
+         *
+         * @param {WordArray} wordArray The word array to append.
+         *
+         * @return {WordArray} This word array.
+         *
+         * @example
+         *
+         *     wordArray1.concat(wordArray2);
+         */
+        concat: function (wordArray) {
+            // Shortcuts
+            var thisWords = this.words;
+            var thatWords = wordArray.words;
+            var thisSigBytes = this.sigBytes;
+            var thatSigBytes = wordArray.sigBytes;
+
+            // Clamp excess bits
+            this.clamp();
+
+            // Concat
+            if (thisSigBytes % 4) {
+                // Copy one byte at a time
+                for (var i = 0; i < thatSigBytes; i++) {
+                    var thatByte = (thatWords[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
+                    thisWords[(thisSigBytes + i) >>> 2] |= thatByte << (24 - ((thisSigBytes + i) % 4) * 8);
+                }
+            } else {
+                // Copy one word at a time
+                for (var i = 0; i < thatSigBytes; i += 4) {
+                    thisWords[(thisSigBytes + i) >>> 2] = thatWords[i >>> 2];
+                }
+            }
+            this.sigBytes += thatSigBytes;
+
+            // Chainable
+            return this;
+        },
+
+        /**
+         * Removes insignificant bits.
+         *
+         * @example
+         *
+         *     wordArray.clamp();
+         */
+        clamp: function () {
+            // Shortcuts
+            var words = this.words;
+            var sigBytes = this.sigBytes;
+
+            // Clamp
+            words[sigBytes >>> 2] &= 0xffffffff << (32 - (sigBytes % 4) * 8);
+            words.length = Math.ceil(sigBytes / 4);
+        },
+
+        /**
+         * Creates a copy of this word array.
+         *
+         * @return {WordArray} The clone.
+         *
+         * @example
+         *
+         *     var clone = wordArray.clone();
+         */
+        clone: function () {
+            var clone = Base.clone.call(this);
+            clone.words = this.words.slice(0);
+
+            return clone;
+        },
+
+        /**
+         * Creates a word array filled with random bytes.
+         *
+         * @param {number} nBytes The number of random bytes to generate.
+         *
+         * @return {WordArray} The random word array.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var wordArray = CryptoJS.lib.WordArray.random(16);
+         */
+        random: function (nBytes) {
+            var words = [];
+
+            var r = (function (m_w) {
+                var m_w = m_w;
+                var m_z = 0x3ade68b1;
+                var mask = 0xffffffff;
+
+                return function () {
+                    m_z = (0x9069 * (m_z & 0xFFFF) + (m_z >> 0x10)) & mask;
+                    m_w = (0x4650 * (m_w & 0xFFFF) + (m_w >> 0x10)) & mask;
+                    var result = ((m_z << 0x10) + m_w) & mask;
+                    result /= 0x100000000;
+                    result += 0.5;
+                    return result * (Math.random() > .5 ? 1 : -1);
+                }
+            });
+
+            for (var i = 0, rcache; i < nBytes; i += 4) {
+                var _r = r((rcache || Math.random()) * 0x100000000);
+
+                rcache = _r() * 0x3ade67b7;
+                words.push((_r() * 0x100000000) | 0);
+            }
+
+            return new WordArray.init(words, nBytes);
+        }
+    });
+
+    /**
+     * Encoder namespace.
+     */
+    var C_enc = C.enc = {};
+
+    /**
+     * Hex encoding strategy.
+     */
+    var Hex = C_enc.Hex = {
+        /**
+         * Converts a word array to a hex string.
+         *
+         * @param {WordArray} wordArray The word array.
+         *
+         * @return {string} The hex string.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var hexString = CryptoJS.enc.Hex.stringify(wordArray);
+         */
+        stringify: function (wordArray) {
+            // Shortcuts
+            var words = wordArray.words;
+            var sigBytes = wordArray.sigBytes;
+
+            // Convert
+            var hexChars = [];
+            for (var i = 0; i < sigBytes; i++) {
+                var bite = (words[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
+                hexChars.push((bite >>> 4).toString(16));
+                hexChars.push((bite & 0x0f).toString(16));
+            }
+
+            return hexChars.join('');
+        },
+
+        /**
+         * Converts a hex string to a word array.
+         *
+         * @param {string} hexStr The hex string.
+         *
+         * @return {WordArray} The word array.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var wordArray = CryptoJS.enc.Hex.parse(hexString);
+         */
+        parse: function (hexStr) {
+            // Shortcut
+            var hexStrLength = hexStr.length;
+
+            // Convert
+            var words = [];
+            for (var i = 0; i < hexStrLength; i += 2) {
+                words[i >>> 3] |= parseInt(hexStr.substr(i, 2), 16) << (24 - (i % 8) * 4);
+            }
+
+            return new WordArray.init(words, hexStrLength / 2);
+        }
+    };
+
+    /**
+     * Latin1 encoding strategy.
+     */
+    var Latin1 = C_enc.Latin1 = {
+        /**
+         * Converts a word array to a Latin1 string.
+         *
+         * @param {WordArray} wordArray The word array.
+         *
+         * @return {string} The Latin1 string.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var latin1String = CryptoJS.enc.Latin1.stringify(wordArray);
+         */
+        stringify: function (wordArray) {
+            // Shortcuts
+            var words = wordArray.words;
+            var sigBytes = wordArray.sigBytes;
+
+            // Convert
+            var latin1Chars = [];
+            for (var i = 0; i < sigBytes; i++) {
+                var bite = (words[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff;
+                latin1Chars.push(String.fromCharCode(bite));
+            }
+
+            return latin1Chars.join('');
+        },
+
+        /**
+         * Converts a Latin1 string to a word array.
+         *
+         * @param {string} latin1Str The Latin1 string.
+         *
+         * @return {WordArray} The word array.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var wordArray = CryptoJS.enc.Latin1.parse(latin1String);
+         */
+        parse: function (latin1Str) {
+            // Shortcut
+            var latin1StrLength = latin1Str.length;
+
+            // Convert
+            var words = [];
+            for (var i = 0; i < latin1StrLength; i++) {
+                words[i >>> 2] |= (latin1Str.charCodeAt(i) & 0xff) << (24 - (i % 4) * 8);
+            }
+
+            return new WordArray.init(words, latin1StrLength);
+        }
+    };
+
+    /**
+     * UTF-8 encoding strategy.
+     */
+    var Utf8 = C_enc.Utf8 = {
+        /**
+         * Converts a word array to a UTF-8 string.
+         *
+         * @param {WordArray} wordArray The word array.
+         *
+         * @return {string} The UTF-8 string.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var utf8String = CryptoJS.enc.Utf8.stringify(wordArray);
+         */
+        stringify: function (wordArray) {
+            try {
+                return decodeURIComponent(escape(Latin1.stringify(wordArray)));
+            } catch (e) {
+                throw new Error('Malformed UTF-8 data');
+            }
+        },
+
+        /**
+         * Converts a UTF-8 string to a word array.
+         *
+         * @param {string} utf8Str The UTF-8 string.
+         *
+         * @return {WordArray} The word array.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var wordArray = CryptoJS.enc.Utf8.parse(utf8String);
+         */
+        parse: function (utf8Str) {
+            return Latin1.parse(unescape(encodeURIComponent(utf8Str)));
+        }
+    };
+
+    /**
+     * Abstract buffered block algorithm template.
+     *
+     * The property blockSize must be implemented in a concrete subtype.
+     *
+     * @property {number} _minBufferSize The number of blocks that should be kept unprocessed in the buffer. Default: 0
+     */
+    var BufferedBlockAlgorithm = C_lib.BufferedBlockAlgorithm = Base.extend({
+        /**
+         * Resets this block algorithm's data buffer to its initial state.
+         *
+         * @example
+         *
+         *     bufferedBlockAlgorithm.reset();
+         */
+        reset: function () {
+            // Initial values
+            this._data = new WordArray.init();
+            this._nDataBytes = 0;
+        },
+
+        /**
+         * Adds new data to this block algorithm's buffer.
+         *
+         * @param {WordArray|string} data The data to append. Strings are converted to a WordArray using UTF-8.
+         *
+         * @example
+         *
+         *     bufferedBlockAlgorithm._append('data');
+         *     bufferedBlockAlgorithm._append(wordArray);
+         */
+        _append: function (data) {
+            // Convert string to WordArray, else assume WordArray already
+            if (typeof data == 'string') {
+                data = Utf8.parse(data);
+            }
+
+            // Append
+            this._data.concat(data);
+            this._nDataBytes += data.sigBytes;
+        },
+
+        /**
+         * Processes available data blocks.
+         *
+         * This method invokes _doProcessBlock(offset), which must be implemented by a concrete subtype.
+         *
+         * @param {boolean} doFlush Whether all blocks and partial blocks should be processed.
+         *
+         * @return {WordArray} The processed data.
+         *
+         * @example
+         *
+         *     var processedData = bufferedBlockAlgorithm._process();
+         *     var processedData = bufferedBlockAlgorithm._process(!!'flush');
+         */
+        _process: function (doFlush) {
+            // Shortcuts
+            var data = this._data;
+            var dataWords = data.words;
+            var dataSigBytes = data.sigBytes;
+            var blockSize = this.blockSize;
+            var blockSizeBytes = blockSize * 4;
+
+            // Count blocks ready
+            var nBlocksReady = dataSigBytes / blockSizeBytes;
+            if (doFlush) {
+                // Round up to include partial blocks
+                nBlocksReady = Math.ceil(nBlocksReady);
+            } else {
+                // Round down to include only full blocks,
+                // less the number of blocks that must remain in the buffer
+                nBlocksReady = Math.max((nBlocksReady | 0) - this._minBufferSize, 0);
+            }
+
+            // Count words ready
+            var nWordsReady = nBlocksReady * blockSize;
+
+            // Count bytes ready
+            var nBytesReady = Math.min(nWordsReady * 4, dataSigBytes);
+
+            // Process blocks
+            if (nWordsReady) {
+                for (var offset = 0; offset < nWordsReady; offset += blockSize) {
+                    // Perform concrete-algorithm logic
+                    this._doProcessBlock(dataWords, offset);
+                }
+
+                // Remove processed words
+                var processedWords = dataWords.splice(0, nWordsReady);
+                data.sigBytes -= nBytesReady;
+            }
+
+            // Return processed words
+            return new WordArray.init(processedWords, nBytesReady);
+        },
+
+        /**
+         * Creates a copy of this object.
+         *
+         * @return {Object} The clone.
+         *
+         * @example
+         *
+         *     var clone = bufferedBlockAlgorithm.clone();
+         */
+        clone: function () {
+            var clone = Base.clone.call(this);
+            clone._data = this._data.clone();
+
+            return clone;
+        },
+
+        _minBufferSize: 0
+    });
+
+    /**
+     * Abstract hasher template.
+     *
+     * @property {number} blockSize The number of 32-bit words this hasher operates on. Default: 16 (512 bits)
+     */
+    var Hasher = C_lib.Hasher = BufferedBlockAlgorithm.extend({
+        /**
+         * Configuration options.
+         */
+        cfg: Base.extend(),
+
+        /**
+         * Initializes a newly created hasher.
+         *
+         * @param {Object} cfg (Optional) The configuration options to use for this hash computation.
+         *
+         * @example
+         *
+         *     var hasher = CryptoJS.algo.SHA256.create();
+         */
+        init: function (cfg) {
+            // Apply config defaults
+            this.cfg = this.cfg.extend(cfg);
+
+            // Set initial values
+            this.reset();
+        },
+
+        /**
+         * Resets this hasher to its initial state.
+         *
+         * @example
+         *
+         *     hasher.reset();
+         */
+        reset: function () {
+            // Reset data buffer
+            BufferedBlockAlgorithm.reset.call(this);
+
+            // Perform concrete-hasher logic
+            this._doReset();
+        },
+
+        /**
+         * Updates this hasher with a message.
+         *
+         * @param {WordArray|string} messageUpdate The message to append.
+         *
+         * @return {Hasher} This hasher.
+         *
+         * @example
+         *
+         *     hasher.update('message');
+         *     hasher.update(wordArray);
+         */
+        update: function (messageUpdate) {
+            // Append
+            this._append(messageUpdate);
+
+            // Update the hash
+            this._process();
+
+            // Chainable
+            return this;
+        },
+
+        /**
+         * Finalizes the hash computation.
+         * Note that the finalize operation is effectively a destructive, read-once operation.
+         *
+         * @param {WordArray|string} messageUpdate (Optional) A final message update.
+         *
+         * @return {WordArray} The hash.
+         *
+         * @example
+         *
+         *     var hash = hasher.finalize();
+         *     var hash = hasher.finalize('message');
+         *     var hash = hasher.finalize(wordArray);
+         */
+        finalize: function (messageUpdate) {
+            // Final message update
+            if (messageUpdate) {
+                this._append(messageUpdate);
+            }
+
+            // Perform concrete-hasher logic
+            var hash = this._doFinalize();
+
+            return hash;
+        },
+
+        blockSize: 512/32,
+
+        /**
+         * Creates a shortcut function to a hasher's object interface.
+         *
+         * @param {Hasher} hasher The hasher to create a helper for.
+         *
+         * @return {Function} The shortcut function.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var SHA256 = CryptoJS.lib.Hasher._createHelper(CryptoJS.algo.SHA256);
+         */
+        _createHelper: function (hasher) {
+            return function (message, cfg) {
+                return new hasher.init(cfg).finalize(message);
+            };
+        },
+
+        /**
+         * Creates a shortcut function to the HMAC's object interface.
+         *
+         * @param {Hasher} hasher The hasher to use in this HMAC helper.
+         *
+         * @return {Function} The shortcut function.
+         *
+         * @static
+         *
+         * @example
+         *
+         *     var HmacSHA256 = CryptoJS.lib.Hasher._createHmacHelper(CryptoJS.algo.SHA256);
+         */
+        _createHmacHelper: function (hasher) {
+            return function (message, key) {
+                return new C_algo.HMAC.init(hasher, key).finalize(message);
+            };
+        }
+    });
+
+    /**
+     * Algorithm namespace.
+     */
+    var C_algo = C.algo = {};
+
+    return C;
+}(Math));

--- a/CryptoJS/lib-typedarrays.js
+++ b/CryptoJS/lib-typedarrays.js
@@ -1,0 +1,56 @@
+(function () {
+    // Check if typed arrays are supported
+    if (typeof ArrayBuffer != 'function') {
+        return;
+    }
+
+    // Shortcuts
+    var C = CryptoJS;
+    var C_lib = C.lib;
+    var WordArray = C_lib.WordArray;
+
+    // Reference original init
+    var superInit = WordArray.init;
+
+    // Augment WordArray.init to handle typed arrays
+    var subInit = WordArray.init = function (typedArray) {
+        // Convert buffers to uint8
+        if (typedArray instanceof ArrayBuffer) {
+            typedArray = new Uint8Array(typedArray);
+        }
+
+        // Convert other array views to uint8
+        if (
+            typedArray instanceof Int8Array ||
+            (typeof Uint8ClampedArray !== "undefined" && typedArray instanceof Uint8ClampedArray) ||
+            typedArray instanceof Int16Array ||
+            typedArray instanceof Uint16Array ||
+            typedArray instanceof Int32Array ||
+            typedArray instanceof Uint32Array ||
+            typedArray instanceof Float32Array ||
+            typedArray instanceof Float64Array
+        ) {
+            typedArray = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+        }
+
+        // Handle Uint8Array
+        if (typedArray instanceof Uint8Array) {
+            // Shortcut
+            var typedArrayByteLength = typedArray.byteLength;
+
+            // Extract bytes
+            var words = [];
+            for (var i = 0; i < typedArrayByteLength; i++) {
+                words[i >>> 2] |= typedArray[i] << (24 - (i % 4) * 8);
+            }
+
+            // Initialize this word array
+            superInit.call(this, words, typedArrayByteLength);
+        } else {
+            // Else call normal init
+            superInit.apply(this, arguments);
+        }
+    };
+
+    subInit.prototype = WordArray;
+}());

--- a/CryptoJS/sha1.js
+++ b/CryptoJS/sha1.js
@@ -1,0 +1,130 @@
+(function () {
+    // Shortcuts
+    var C = CryptoJS;
+    var C_lib = C.lib;
+    var WordArray = C_lib.WordArray;
+    var Hasher = C_lib.Hasher;
+    var C_algo = C.algo;
+
+    // Reusable object
+    var W = [];
+
+    /**
+     * SHA-1 hash algorithm.
+     */
+    var SHA1 = C_algo.SHA1 = Hasher.extend({
+        _doReset: function () {
+            this._hash = new WordArray.init([
+                0x67452301, 0xefcdab89,
+                0x98badcfe, 0x10325476,
+                0xc3d2e1f0
+            ]);
+        },
+
+        _doProcessBlock: function (M, offset) {
+            // Shortcut
+            var H = this._hash.words;
+
+            // Working variables
+            var a = H[0];
+            var b = H[1];
+            var c = H[2];
+            var d = H[3];
+            var e = H[4];
+
+            // Computation
+            for (var i = 0; i < 80; i++) {
+                if (i < 16) {
+                    W[i] = M[offset + i] | 0;
+                } else {
+                    var n = W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16];
+                    W[i] = (n << 1) | (n >>> 31);
+                }
+
+                var t = ((a << 5) | (a >>> 27)) + e + W[i];
+                if (i < 20) {
+                    t += ((b & c) | (~b & d)) + 0x5a827999;
+                } else if (i < 40) {
+                    t += (b ^ c ^ d) + 0x6ed9eba1;
+                } else if (i < 60) {
+                    t += ((b & c) | (b & d) | (c & d)) - 0x70e44324;
+                } else /* if (i < 80) */ {
+                    t += (b ^ c ^ d) - 0x359d3e2a;
+                }
+
+                e = d;
+                d = c;
+                c = (b << 30) | (b >>> 2);
+                b = a;
+                a = t;
+            }
+
+            // Intermediate hash value
+            H[0] = (H[0] + a) | 0;
+            H[1] = (H[1] + b) | 0;
+            H[2] = (H[2] + c) | 0;
+            H[3] = (H[3] + d) | 0;
+            H[4] = (H[4] + e) | 0;
+        },
+
+        _doFinalize: function () {
+            // Shortcuts
+            var data = this._data;
+            var dataWords = data.words;
+
+            var nBitsTotal = this._nDataBytes * 8;
+            var nBitsLeft = data.sigBytes * 8;
+
+            // Add padding
+            dataWords[nBitsLeft >>> 5] |= 0x80 << (24 - nBitsLeft % 32);
+            dataWords[(((nBitsLeft + 64) >>> 9) << 4) + 14] = Math.floor(nBitsTotal / 0x100000000);
+            dataWords[(((nBitsLeft + 64) >>> 9) << 4) + 15] = nBitsTotal;
+            data.sigBytes = dataWords.length * 4;
+
+            // Hash final blocks
+            this._process();
+
+            // Return final computed hash
+            return this._hash;
+        },
+
+        clone: function () {
+            var clone = Hasher.clone.call(this);
+            clone._hash = this._hash.clone();
+
+            return clone;
+        }
+    });
+
+    /**
+     * Shortcut function to the hasher's object interface.
+     *
+     * @param {WordArray|string} message The message to hash.
+     *
+     * @return {WordArray} The hash.
+     *
+     * @static
+     *
+     * @example
+     *
+     *     var hash = CryptoJS.SHA1('message');
+     *     var hash = CryptoJS.SHA1(wordArray);
+     */
+    C.SHA1 = Hasher._createHelper(SHA1);
+
+    /**
+     * Shortcut function to the HMAC's object interface.
+     *
+     * @param {WordArray|string} message The message to hash.
+     * @param {WordArray|string} key The secret key.
+     *
+     * @return {WordArray} The HMAC.
+     *
+     * @static
+     *
+     * @example
+     *
+     *     var hmac = CryptoJS.HmacSHA1(message, key);
+     */
+    C.HmacSHA1 = Hasher._createHmacHelper(SHA1);
+}());

--- a/MsUpload.body.php
+++ b/MsUpload.body.php
@@ -5,7 +5,7 @@ class MsUpload {
 	static function start() {
 		global $wgOut, $wgScriptPath, $wgMSU_useMsLinks, $wgMSU_showAutoCat, $wgMSU_checkAutoCat,
 			$wgMSU_confirmReplace, $wgMSU_useDragDrop, $wgMSU_imgParams, $wgFileExtensions,
-			$wgMSU_uploadsize, $wgMSU_flash_swf_url, $wgMSU_silverlight_xap_url;
+			$wgMSU_uploadsize, $wgMSU_flash_swf_url, $wgMSU_silverlight_xap_url, $wgMSU_disallowReplaceFile;
 
 		$wgMSU_flash_swf_url = __DIR__ . '/plupload/Moxie.swf';
 		$wgMSU_silverlight_xap_url = __DIR__ . '/plupload/Moxie.xap';

--- a/MsUpload.body.php
+++ b/MsUpload.body.php
@@ -27,6 +27,7 @@ class MsUpload {
 			'checkAutoCat' => $wgMSU_checkAutoCat,
 			'useMsLinks' => $wgMSU_useMsLinks,
 			'confirmReplace' => $wgMSU_confirmReplace,
+			'disallowReplaceFile' => $wgMSU_disallowReplaceFile,
 			'imgParams' => $wgMSU_imgParams,
 			'uploadsize' => $wgMSU_uploadsize,
 		);

--- a/MsUpload.css
+++ b/MsUpload.css
@@ -15,7 +15,7 @@
 }
 
 #msupload-select:hover {
-	opacity: 0.7; 
+	opacity: 0.7;
 	zoom: 1;
 }
 
@@ -24,7 +24,7 @@
 	background: #657d91;
 	border: 1px solid #aaa;
 	z-index: 0;
-} 
+}
 
 #msupload-div a {
 	cursor: pointer;
@@ -151,7 +151,7 @@
 }
 
 #msupload-list .file .file-cancel:hover {
-	opacity: 0.7; 
+	opacity: 0.7;
 }
 
 #msupload-list .file .file-loading {
@@ -223,10 +223,14 @@
 	 height: 22px;
 }
 
-#msupload-bottom a {
+#msupload-bottom a, #msupload-bottom span {
 	color: white;
 	font-weight: bold;
 	margin-right: 20px;
+}
+
+#msupload-bottom span.upload-error {
+	color: red;
 }
 
 #msupload-bottom #msupload-files {

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -81,8 +81,13 @@
 						$( fileItem.warning ).find( 'div.thumb' ).hide();
 					} );
 
+					if ( msuVars.disallowReplaceFile ) {
+						// do nothing. files will maintain "data-no-upload" marker and will fail checks later
+					}
+
 					// If a file with the same name already exists, add a checkbox to confirm the replacement
-					if ( msuVars.confirmReplace ) {
+					// checkbox will rmeove "data-no-upload" from file so it'll pass checks later
+					else if ( msuVars.confirmReplace ) {
 
 						var title = $( fileItem.warning ).siblings( '.file-name' );
 
@@ -97,6 +102,11 @@
 							uploader.trigger( 'CheckFiles' );
 						} );
 						$( '<label>' ).append( checkbox ).append( mw.msg( 'msu-replace-file' ) ).appendTo( fileItem.warning );
+					}
+
+					// Without checkbox, just strip "data-no-upload" to allow replacing file (dangerous!)
+					else {
+						fileItem.removeAttr( "data-no-upload" );
 					}
 					break;
 			}

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -34,11 +34,11 @@
 		},
 
 		warningText: function ( fileItem, warning, uploader ) {
-			fileItem.attr( "data-no-upload", "true" );
 			switch ( warning ) {
 				case '':
 				case '&nbsp;':
 				case '&#160;':
+					// uploads allowed
 					$( fileItem.warning ).empty()
 						.siblings( '.file-name' ).show()
 						.siblings( '.file-name-input' ).hide()
@@ -47,10 +47,15 @@
 
 				case 'Error: Unknown result from API':
 				case 'Error: Request failed':
+					// uploads not allowed
+					fileItem.attr( "data-no-upload", "true" );
 					$( fileItem.warning ).text( warning );
 					break;
 
 				default:
+					// uploads not allowed (unless "replace" is checked on file name collisions)
+					fileItem.attr( "data-no-upload", "true" );
+
 					// IMPORTANT! The code below assumes that every warning not captured by the code above is about a file being replaced
 					$( fileItem.warning ).html( warning );
 
@@ -322,6 +327,7 @@
 				uploadList = $( '<ul>' ).attr( 'id', 'msupload-list' ),
 				bottomDiv = $( '<div>' ).attr( 'id', 'msupload-bottom' ).hide(),
 				startButton = $( '<a>' ).attr( 'id', 'msupload-files' ).hide(),
+				noUploadMesage = $( '<span>' ).attr( 'id', 'msupload-no-upload-msg' ).text( mw.msg( 'msu-no-upload-msg' ) ).hide(),
 				cleanAll = $( '<a>' ).attr( 'id', 'msupload-clean-all' ).text( mw.msg( 'msu-clean-all' ) ).hide(),
 				galleryInsert = $( '<a>' ).attr( 'id', 'msupload-insert-gallery' ).hide(),
 				filesInsert = $( '<a>' ).attr( 'id', 'msupload-insert-files' ).hide(),
@@ -515,23 +521,36 @@
 
 			mw.log( 'files: ' + filesLength + ', gallery: ' + MsUpload.galleryArray.length + ', list: ' + listLength );
 
+			for( var i = 0; i < filesLength; i++ ) {
+				if ( uploader.files[i].li.attr( "data-no-upload" ) === "true" ) {
+					disableUploads = true; // if any file is un-uploadable, disable uploads
+					break;
+				}
+			}
+
 			if ( filesLength ) {
-				$( '#msupload-bottom' ).show();
 				if ( filesLength === 1 ) {
 					$( '#msupload-files' ).text( mw.msg( 'msu-upload-this' ) ).show();
 				} else {
 					$( '#msupload-files' ).text( mw.msg( 'msu-upload-all' ) ).show();
 				}
+
+				if ( disableUploads ) {
+					$( '#msupload-files' ).hide(); // hide upload button
+					$( '#msupload-no-upload-msg' ).show(); // show explanation
+				}
+				else {
+					$( '#msupload-files' ).show();
+					$( '#msupload-no-upload-msg' ).hide();
+				}
 			} else {
+				// no uploads pending, don't show upload button or message about why you can't upload
 				$( '#msupload-files' ).hide();
+				$( '#msupload-no-upload-msg' ).hide();
 			}
 
-			for( var i = 0; i < filesLength; i++ ) {
-				if ( uploader.files[i].li.attr( "data-no-upload" ) === "true" ) {
-					$( '#msupload-files' ).hide(); // if any file is un-uploadable, hide upload button
-					break;
-				}
-			}
+
+
 
 			if ( MsUpload.filesArray.length > 1 ) {
 				$( '#msupload-insert-files' ).show();

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -33,8 +33,8 @@
 			}
 		},
 
-		unconfirmedReplacements: 0,
 		warningText: function ( fileItem, warning, uploader ) {
+			fileItem.attr( "data-no-upload", "true" );
 			switch ( warning ) {
 				case '':
 				case '&nbsp;':
@@ -79,17 +79,15 @@
 					// If a file with the same name already exists, add a checkbox to confirm the replacement
 					if ( msuVars.confirmReplace ) {
 
-						MsUpload.unconfirmedReplacements++;
-
 						var title = $( fileItem.warning ).siblings( '.file-name' );
 
 						var checkbox = $( '<input>' ).attr( 'type', 'checkbox' ).click( function () {
 							if ( $( this ).is( ':checked' ) ) {
 								title.show().next().hide();
-								MsUpload.unconfirmedReplacements--;
+								fileItem.removeAttr( "data-no-upload" );
 							} else {
 								title.hide().next().show().select();
-								MsUpload.unconfirmedReplacements++;
+								fileItem.attr( "data-no-upload", "true" );
 							}
 							uploader.trigger( 'CheckFiles' );
 						} );
@@ -162,7 +160,6 @@
 
 			});
 
-
 		},
 
 		getFileSha1: function ( file, callback ) {
@@ -218,7 +215,7 @@
 			} ).change( function () {
 				file.name = this.value + '.' + file.extension;
 				$( this ).prev().text( file.name );
-				MsUpload.unconfirmedReplacements = 0; // Hack! If the user renames a file to avoid replacing it, this forces the Upload button to appear, but it also does when a user just renames a file that wasn't about to replace another
+				// MsUpload.unconfirmedReplacements = 0; // Hack! If the user renames a file to avoid replacing it, this forces the Upload button to appear, but it also does when a user just renames a file that wasn't about to replace another
 				MsUpload.checkUploadWarning( this.value, file.li, uploader, file );
 			} ).keydown( function ( event ) {
 				// For convenience, when pressing enter, save the new title
@@ -529,8 +526,11 @@
 				$( '#msupload-files' ).hide();
 			}
 
-			if ( MsUpload.unconfirmedReplacements ) {
-				$( '#msupload-files' ).hide();
+			for( var i = 0; i < filesLength; i++ ) {
+				if ( uploader.files[i].li.attr( "data-no-upload" ) === "true" ) {
+					$( '#msupload-files' ).hide(); // if any file is un-uploadable, hide upload button
+					break;
+				}
 			}
 
 			if ( MsUpload.filesArray.length > 1 ) {

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -62,8 +62,10 @@
 						break; // Make it work for German too. Must be done this way because the error response doesn't include an error code.
 					}
 
-					if ( warning.indexOf( 'This file has identical content to' ) === 0 ) {
-						// don't allow replacing a file with identical content
+					// if warning message starts with content of
+					// msu-identical-content message, don't allow replacing file
+					var identicalMsg = mw.message( 'msu-identical-content', "" ).plain();
+					if ( warning.indexOf( identicalMsg ) === 0 ) {
 						break;
 					}
 
@@ -136,21 +138,19 @@
 					list: 'allimages',
 					aiprop: 'url|canonicaltitle',
 					aisha1: sha1
-					// aisha1base36: 'ct1tbf6eyd66c3cfn5iy565vdbyyw06' // example base36 sha1 from MW database
 				}, success: function ( data ) {
 					if ( data && data.query && data.query.allimages ) {
 						var dupeImages = data.query.allimages;
 						if ( dupeImages.length > 0 ) {
-							var warningMsg = "This file has identical content to ";
 							var dupeLinks = [];
 							for ( var i = 0; i < dupeImages.length; i++ ) {
-								dupeLinks.push(
-									"<a href='" + dupeImages[i].descriptionurl
-									+ "'>" + dupeImages[i].canonicaltitle
-									+ "</a>"
+								dupeLinks.push( mw.html.element(
+									'a',
+									{ href: dupeImages[i].descriptionurl },
+									dupeImages[i].canonicaltitle )
 								);
 							}
-							warningMsg += dupeLinks.join( ", " );
+							var warningMsg = mw.message( 'msu-identical-content', dupeLinks.join( ", " ) ).plain();
 							MsUpload.warningText( fileItem, warningMsg, uploader );
 						}
 					} else {

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -335,7 +335,7 @@
 				uploadDrop = $( '<div>' ).attr( 'id', 'msupload-dropzone' ).hide();
 
 			// Add them to the DOM
-			bottomDiv.append( startButton, cleanAll, galleryInsert, filesInsert, linksInsert );
+			bottomDiv.append( startButton, noUploadMesage, cleanAll, galleryInsert, filesInsert, linksInsert );
 			uploadDiv.append( statusDiv, uploadDrop, uploadList, bottomDiv );
 			$( '#wikiEditor-ui-toolbar' ).after( uploadDiv );
 			uploadContainer.append( uploadButton );
@@ -521,6 +521,7 @@
 
 			mw.log( 'files: ' + filesLength + ', gallery: ' + MsUpload.galleryArray.length + ', list: ' + listLength );
 
+			var disableUploads = false;
 			for( var i = 0; i < filesLength; i++ ) {
 				if ( uploader.files[i].li.attr( "data-no-upload" ) === "true" ) {
 					disableUploads = true; // if any file is un-uploadable, disable uploads

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -125,8 +125,10 @@
 				} else {
 					MsUpload.warningText( fileItem, 'Error: Unknown result from API', uploader );
 				}
+				uploader.trigger( 'CheckFiles' );
 			}, error: function () {
 				MsUpload.warningText( fileItem, 'Error: Request failed', uploader );
+				uploader.trigger( 'CheckFiles' );
 			} } );
 
 			// generate sha1 has to send to allimages API
@@ -159,8 +161,10 @@
 					} else {
 						MsUpload.warningText( fileItem, 'Error: Unknown result from API', uploader );
 					}
+					uploader.trigger( 'CheckFiles' );
 				}, error: function () {
 					MsUpload.warningText( fileItem, 'Error: Request failed', uploader );
+					uploader.trigger( 'CheckFiles' );
 				} } );
 
 			});
@@ -327,7 +331,10 @@
 				uploadList = $( '<ul>' ).attr( 'id', 'msupload-list' ),
 				bottomDiv = $( '<div>' ).attr( 'id', 'msupload-bottom' ).hide(),
 				startButton = $( '<a>' ).attr( 'id', 'msupload-files' ).hide(),
-				noUploadMesage = $( '<span>' ).attr( 'id', 'msupload-no-upload-msg' ).text( mw.msg( 'msu-no-upload-msg' ) ).hide(),
+				noUploadMesage = $( '<span>' ).attr( {
+					'id': 'msupload-no-upload-msg',
+					'class': 'upload-error'
+				} ).text( mw.msg( 'msu-no-upload-msg' ) ).hide(),
 				cleanAll = $( '<a>' ).attr( 'id', 'msupload-clean-all' ).text( mw.msg( 'msu-clean-all' ) ).hide(),
 				galleryInsert = $( '<a>' ).attr( 'id', 'msupload-insert-gallery' ).hide(),
 				filesInsert = $( '<a>' ).attr( 'id', 'msupload-insert-files' ).hide(),

--- a/MsUpload.js
+++ b/MsUpload.js
@@ -106,6 +106,8 @@
 
 		checkUploadWarning: function ( filename, fileItem, uploader, file ) {
 
+			fileItem.removeAttr( "data-no-upload" );
+
 			// Check filename via imageinfo API
 			// ref: https://www.mediawiki.org/wiki/API:Imageinfo
 			$.ajax( { url: mw.util.wikiScript( 'api' ), dataType: 'json', type: 'POST',

--- a/extension.json
+++ b/extension.json
@@ -45,6 +45,7 @@
 				"msu-upload-all",
 				"msu-dropzone",
 				"msu-identical-content",
+				"msu-no-upload-msg",
 				"msu-comment"
 			]
 		}

--- a/extension.json
+++ b/extension.json
@@ -44,6 +44,7 @@
 				"msu-upload-this",
 				"msu-upload-all",
 				"msu-dropzone",
+				"msu-identical-content",
 				"msu-comment"
 			]
 		}

--- a/extension.json
+++ b/extension.json
@@ -68,6 +68,7 @@
 		"MSU_checkAutoCat": true,
 		"MSU_useMsLinks": false,
 		"MSU_confirmReplace": true,
+		"MSU_disallowReplaceFile": false,
 		"MSU_imgParams": "400px",
 		"MSU_uploadsize": "100mb"
 	},

--- a/extension.json
+++ b/extension.json
@@ -21,6 +21,9 @@
 	"ResourceModules": {
 		"ext.MsUpload": {
 			"scripts": [
+				"CryptoJS/core.js",
+				"CryptoJS/lib-typedarrays.js",
+				"CryptoJS/sha1.js",
 				"plupload/plupload.full.min.js",
 				"MsUpload.js"
 			],

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -21,5 +21,6 @@
 	"msu-upload-this": "Upload this file",
 	"msu-upload-all": "Upload all files",
 	"msu-dropzone": "Drop files here",
+	"msu-identical-content": "This file has identical content to $1",
 	"msu-comment": "File uploaded with MsUpload"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,5 +22,6 @@
 	"msu-upload-all": "Upload all files",
 	"msu-dropzone": "Drop files here",
 	"msu-identical-content": "This file has identical content to $1",
+	"msu-no-upload-msg": "Fix file errors above to upload",
 	"msu-comment": "File uploaded with MsUpload"
 }


### PR DESCRIPTION
This PR adds a check for duplicate files. It does so by using CryptoJS to calculate the sha1 sum of the file, then sending a request to the MediaWiki [`allimages` API](https://www.mediawiki.org/wiki/API:Allimages) to see if there are any other files with the same sha1.

Additionally, this PR modifies the logic for when it is possible to view/click the "upload files" link. These changes were required because there are now competing conditions for when a file is uploadable. A CSS change was also made to clearly indicate when action is required to make files uploadable.

Lastly, the `wgMSU_disallowReplaceFile` configuration variable was added. The logic changes above added some confusion about when it should be possible to replace a file. This config var allows you to totally remove that capability.